### PR TITLE
TEvaluteArguments.FrameID should be integer

### DIFF
--- a/source/BaseProtocol.Requests.pas
+++ b/source/BaseProtocol.Requests.pas
@@ -760,14 +760,14 @@ type
     [JSONName('expression')]
     FExpression: string;
     [JSONName('frameId')]
-    FFrameId: string;
+    FFrameId: integer;
     [JSONName('context'), JSONReflect(ctString, rtString, TEnumInterceptor)]
     FContext: TEvaluteContext;
     [JSONName('format'), Managed()]
     FFormat: TValueFormat;
   public
     property Expression: string read FExpression write FExpression;
-    property FrameId: string read FFrameId write FFrameId;
+    property FrameId: Integer read FFrameId write FFrameId;
     property Context: TEvaluteContext read FContext write FContext;
     property Format: TValueFormat read FFormat write FFormat;
   end;


### PR DESCRIPTION
It was defined as String which does not meet DAP specification and does not work with debugpy